### PR TITLE
find_imports: only list missing packages

### DIFF
--- a/src/sandbox/py/python/runtime/api.py
+++ b/src/sandbox/py/python/runtime/api.py
@@ -3,6 +3,7 @@ import js
 import micropip
 import pyodide
 import os
+import importlib
 
 
 async def micropip_install(packages, id, keep_going=False):
@@ -68,8 +69,7 @@ async def format_code(code, id):
 
 
 def find_imports(code):
-    return pyodide.code.find_imports(code)
-
+    return [package for package in pyodide.code.find_imports(code) if importlib.util.find_spec(package) is None]
 
 __all__ = [
     "micropip_install",


### PR DESCRIPTION
Currently pysandbox tries to micropip.install() all packages from imports even if they are already loaded, e.g.:
- packages from the standard library like "os"
- packages loaded previously from another call to micropip.install()
- relative imports from the filesystem

It works, but there are many errors in the dev console.

This PR changes `find_imports()` to filter out the existing packages to avoid the errors.
